### PR TITLE
fix: change `trailingComma` to `es5` following minimum Node version

### DIFF
--- a/base.js
+++ b/base.js
@@ -19,7 +19,7 @@ module.exports = {
       {
         semi: false,
         singleQuote: true,
-        trailingComma: 'all',
+        trailingComma: 'es5',
       },
     ],
   },


### PR DESCRIPTION
Node 6 (minimum support version) doesn't support "Trailing commas".

See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas