### PR TITLE
ci(travis): drop Node 9, add Node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - 9
+  - 10
   - 8
   - 6
 


### PR DESCRIPTION
Node 10 was released on Apr 2018. See <https://github.com/nodejs/Release>.