### PR TITLE
test: add `--no-init-module` option to `npm init`

### DIFF
--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -27,7 +27,7 @@ test("End-to-End", t => {
   sandbox(() => {
     fs.writeFileSync(".npmrc", npmrc);
 
-    $("npm", "init", "--yes");
+    $("npm", "init", "--yes", "--no-init-module");
     $("npm", "install", ...Object.keys(pkg.peerDependencies), tarballPath);
 
     writeESLintConfig({ extends: "ybiquitous" });


### PR DESCRIPTION
To avoid environment specific problems by a customized `~/.npm-init.js`.