### PR TITLE
chore: remove duplicate `index.js` from `files` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   ],
   "main": "index.js",
   "files": [
-    "index.js",
     "node.js",
     "browser.js",
     "react.js",


### PR DESCRIPTION
`index.js` is already in `main` field.