### PR TITLE
feat(react): disable `jsx-boolean-value` rule

### DIFF
--- a/rules/plugins/react-jsx.js
+++ b/rules/plugins/react-jsx.js
@@ -4,7 +4,7 @@ module.exports = {
   extends: ["prettier/react"],
 
   rules: {
-    "react/jsx-boolean-value": "error",
+    "react/jsx-boolean-value": "off",
     "react/jsx-curly-brace-presence": "error",
     "react/jsx-filename-extension": ["error", { extensions: [".js", ".jsx"] }],
     "react/jsx-fragments": ["error", "syntax"],


### PR DESCRIPTION
Because this rule is about stylistic issues.

https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md