### PR TITLE
ci(travis): do not deploy on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,3 @@ matrix:
 branches:
   only:
     - master
-    - /^v\d+\.\d+.\d+(-\d+)?$/ # e.g. `v3.2.1` | `v3.2.1-0`
-
-deploy:
-  provider: npm
-  email: $NPM_EMAIL
-  api_key: $NPM_TOKEN
-  on:
-    tags: true
-    node: 10

--- a/README.md
+++ b/README.md
@@ -49,4 +49,5 @@ Run the following commands:
 4.  `npm run release:dry-run`
 5.  `npm run release`
 6.  `git push --follow-tags`
-    (`npm publish` does not need, because it will be executed in CI)
+7.  `git checkout <TAG>`
+8.  `npm publish`


### PR DESCRIPTION
The deploy on Travis CI does not support 2FA. So, this changes the release flow to publish on a local machine instead.