### PR TITLE
feat(core): loosen rule `prefer-destructuring`

### DIFF
--- a/rules/core/es6.js
+++ b/rules/core/es6.js
@@ -23,7 +23,7 @@ module.exports = {
     "object-shorthand": "error",
     "prefer-arrow-callback": "error",
     "prefer-const": "error",
-    "prefer-destructuring": "error",
+    "prefer-destructuring": "warn",
     "prefer-numeric-literals": "error",
     "prefer-rest-params": "error",
     "prefer-spread": "error",


### PR DESCRIPTION
This is a stylistic rule. The `error` severity is too strict.

See https://eslint.org/docs/rules/prefer-destructuring