### PR TITLE
feat(core): loosen rule `func-style`

### DIFF
--- a/rules/core/styles.js
+++ b/rules/core/styles.js
@@ -13,7 +13,7 @@ module.exports = {
       },
     ],
     "func-names": ["error", "as-needed"],
-    "func-style": ["error", "expression"],
+    "func-style": "off",
     "id-blacklist": "off",
     "id-length": "off",
     "id-match": "off",


### PR DESCRIPTION
This is a stylistic rule. The `warn` or `error` severity is not helpful in many cases.

See <https://eslint.org/docs/rules/func-style>