### PR TITLE
feat: turn off `no-extra-semi` rule

### DIFF
--- a/rules/core/possible-errors.js
+++ b/rules/core/possible-errors.js
@@ -18,7 +18,6 @@ module.exports = {
     "no-ex-assign": "error",
     "no-extra-boolean-cast": "error",
     "no-extra-parens": "error",
-    "no-extra-semi": "error",
     "no-func-assign": "error",
     "no-import-assign": "error",
     "no-inner-declarations": "error",

--- a/rules/plugins/typescript.js
+++ b/rules/plugins/typescript.js
@@ -16,8 +16,6 @@ module.exports = {
     "@typescript-eslint/member-ordering": "off",
     "@typescript-eslint/no-dynamic-delete": "warn",
     "@typescript-eslint/no-extra-non-null-assertion": "error",
-    "no-extra-semi": "off",
-    "@typescript-eslint/no-extra-semi": "error", // eslint-disable-line sort-keys
     "@typescript-eslint/no-extraneous-class": "error",
     "@typescript-eslint/no-floating-promises": "off",
     "@typescript-eslint/no-for-in-array": "off",


### PR DESCRIPTION
`eslint-config-prettier` disables them instead. See below:

- https://github.com/prettier/eslint-config-prettier/blob/4fdaa044ca252f2f6360dba9d6ef1e43bf03b59a/index.js#L52
- https://github.com/prettier/eslint-config-prettier/blob/4d16ebc6fcd7f87711ab945c41d0ae70d269bdaf/%40typescript-eslint.js#L12