### PR TITLE
feat(typescript): remove deprecated `no-untyped-public-signature`

### DIFF
--- a/rules/plugins/typescript.js
+++ b/rules/plugins/typescript.js
@@ -37,7 +37,6 @@ module.exports = {
     "@typescript-eslint/no-unnecessary-qualifier": "off",
     "@typescript-eslint/no-unnecessary-type-arguments": "off",
     "@typescript-eslint/no-unnecessary-type-assertion": "off",
-    "@typescript-eslint/no-untyped-public-signature": "warn",
     "no-unused-expressions": "off",
     "@typescript-eslint/no-unused-expressions": "error", // eslint-disable-line sort-keys
     "@typescript-eslint/no-unused-vars-experimental": "off",

--- a/test/check-rules.test.js
+++ b/test/check-rules.test.js
@@ -38,11 +38,12 @@ test("deprecated rules", t => {
       checkRules(file, "--deprecated", { ESLINT_CONFIG_PRETTIER_NO_DEPRECATED: "true" });
     } catch (err) {
       if (typeof err.stdout === "string") {
-        const msgs = ignoredRules
+        const msg = ignoredRules
           .filter(rule => err.stdout.includes(rule))
-          .map(rule => `  => "${rule}" is deprecated but included in the recommended config${EOL}`);
-        if (msgs.length !== -1) {
-          process.stderr.write(msgs.join(""));
+          .map(rule => `  => "${rule}" is deprecated but included in the recommended config${EOL}`)
+          .join("");
+        if (msg) {
+          process.stderr.write(msg);
           return;
         }
       }


### PR DESCRIPTION
typescript-eslint/typescript-eslint#1020 has introduced `explicit-module-boundary-types`,
and deprecated `no-untyped-public-signature`.

See also:
- https://github.com/typescript-eslint/typescript-eslint/blob/v2.19.0/packages/eslint-plugin/docs/rules/no-untyped-public-signature.md
- https://github.com/typescript-eslint/typescript-eslint/blob/v2.19.0/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.md