### PR TITLE
chore: set `root: true`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,4 @@
 module.exports = {
+  root: true,
   extends: ["./node.js"],
 };


### PR DESCRIPTION
Since ESLint v7, `~/.eslintrc.*` will be deprecated, and setting `root: true` will be recommended. See below:
https://eslint.org/blog/2020/02/whats-coming-in-eslint-7.0.0#warnings-for-using-eslintrc

See also #643