### PR TITLE
feat(node): disable all Node-specific rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = {
     "./rules/core/variables.js",
     "./rules/core/styles.js",
     "./rules/core/es6.js",
-    "./rules/core/node-disable-all.js",
+    "./rules/core/node.js",
     "./rules/plugins/prettier.js",
     "./rules/plugins/eslint-comments.js",
     "./rules/plugins/import.js",

--- a/node.js
+++ b/node.js
@@ -1,3 +1,3 @@
 module.exports = {
-  extends: ["./index.js", "./rules/core/node.js", "./rules/plugins/node.js"],
+  extends: ["./index.js", "./rules/plugins/node.js"],
 };

--- a/rules/core/node-disable-all.js
+++ b/rules/core/node-disable-all.js
@@ -1,8 +1,0 @@
-const nodeRules = require("./node");
-
-module.exports = {
-  rules: Object.keys(nodeRules.rules).reduce(
-    (newRules, ruleId) => Object.assign(newRules, { [ruleId]: "off" }),
-    {}
-  ),
-};

--- a/rules/core/node.js
+++ b/rules/core/node.js
@@ -1,12 +1,16 @@
+// NOTE: Node-specific rules are deprecated and will be removed.
+//
+// See https://eslint.org/blog/2020/02/whats-coming-in-eslint-7.0.0#deprecating-node-js-commonjs-specific-rules
+
 module.exports = {
   rules: {
-    "callback-return": "error",
+    "callback-return": "off",
     "global-require": "off",
-    "handle-callback-err": "error",
-    "no-buffer-constructor": "error",
+    "handle-callback-err": "off",
+    "no-buffer-constructor": "off",
     "no-mixed-requires": "off",
-    "no-new-require": "error",
-    "no-path-concat": "error",
+    "no-new-require": "off",
+    "no-path-concat": "off",
     "no-process-env": "off",
     "no-process-exit": "off",
     "no-restricted-modules": "off",


### PR DESCRIPTION
Node-specific rules are deprecated and will be removed.
See the [blog post](https://eslint.org/blog/2020/02/whats-coming-in-eslint-7.0.0#deprecating-node-js-commonjs-specific-rules).

Alternatives of these rules have been already provided, so this change should have little effect.
See also <https://eslint.org/docs/rules/#deprecated>.