### PR TITLE
fix(typescript): remove `typescript` from peer-deps

### DIFF
--- a/goodcheck.yml
+++ b/goodcheck.yml
@@ -1,8 +1,8 @@
 rules:
   - id: update-peer-dependencies
     pattern:
-      regexp: '"(eslint|prettier|typescript|@typescript-eslint/.+)": "[0-9.^~]+"'
-    glob: "package.json"
+      regexp: '"(eslint|prettier|@typescript-eslint/.+)": "[0-9.^~]+"'
+    glob: package.json
     message: Don't forget updating `peerDependencies` when updating `devDependencies`.
     justification:
       - When not updating `peerDependencies`.

--- a/package.json
+++ b/package.json
@@ -45,11 +45,10 @@
     "ybiq": "11.0.0"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": ">=2.33.0 <3",
-    "@typescript-eslint/parser": ">=2.33.0 <3",
+    "@typescript-eslint/eslint-plugin": ">=2.34.0 <3",
+    "@typescript-eslint/parser": ">=2.34.0 <3",
     "eslint": ">=6.8.0 <7",
-    "prettier": ">=1.19.1 <3",
-    "typescript": ">=3.7.2 <4"
+    "prettier": ">=1.19.1 <3"
   },
   "peerDependenciesMeta": {
     "@typescript-eslint/eslint-plugin": {
@@ -63,9 +62,6 @@
     },
     "prettier": {
       "optional": false
-    },
-    "typescript": {
-      "optional": true
     }
   },
   "scripts": {


### PR DESCRIPTION
Why?
----

The `typescript` package is required by the `@typescript-eslint/eslint-plugin` package.
So, this `eslint-config-ybiquitous` package does not need to require it as a peer dependency.