### PR TITLE
fix(prettier): remove `prettier` from peer-deps

### DIFF
--- a/goodcheck.yml
+++ b/goodcheck.yml
@@ -1,7 +1,7 @@
 rules:
   - id: update-peer-dependencies
     pattern:
-      regexp: '"(eslint|prettier|@typescript-eslint/.+)": "[0-9.^~]+"'
+      regexp: '"(eslint|@typescript-eslint/.+)": "[0-9.^~]+"'
     glob: package.json
     message: Don't forget updating `peerDependencies` when updating `devDependencies`.
     justification:

--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": ">=2.34.0 <3",
     "@typescript-eslint/parser": ">=2.34.0 <3",
-    "eslint": ">=6.8.0 <7",
-    "prettier": ">=1.19.1 <3"
+    "eslint": ">=6.8.0 <7"
   },
   "peerDependenciesMeta": {
     "@typescript-eslint/eslint-plugin": {
@@ -58,9 +57,6 @@
       "optional": true
     },
     "eslint": {
-      "optional": false
-    },
-    "prettier": {
       "optional": false
     }
   },


### PR DESCRIPTION
Why?
----

The `prettier` package is required by the `eslint-prettier-plugin` package.
So, this `eslint-config-ybiquitous` package does not need to require it as a peer dependency.