### PR TITLE
ci: bump `actions/setup-node` from v1 to v2-beta

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -6,7 +6,7 @@ on:
     branches: [master]
 
 jobs:
-  run:
+  commitlint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -5,7 +5,7 @@ on:
     - cron: 0 0 * * *
 
 jobs:
-  run:
+  fix:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     tags: ["**"]
 
 jobs:
-  run:
+  release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,14 +7,14 @@ on:
     tags: ["**"]
 
 jobs:
-  run:
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: ["10", "12", "14"]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2-beta
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci


### PR DESCRIPTION
See https://github.com/actions/setup-node#v2-beta

Also, this change makes each job name more clear.