### PR TITLE
ci: refactor workflows

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -6,7 +6,7 @@ on:
     branches: [master]
 
 jobs:
-  run:
+  commitlint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -5,7 +5,7 @@ on:
     - cron: 0 0 * * *
 
 jobs:
-  run:
+  audit-fix:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     tags: ["**"]
 
 jobs:
-  run:
+  release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,11 +7,11 @@ on:
     tags: ["**"]
 
 jobs:
-  run:
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: ["10", "12", "14"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2.1.0


### PR DESCRIPTION
- Make each job name more clear.
- Simplify the `node-version` names.