### PR TITLE
feat(core): remove `eslint-restricted-globals` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3201,11 +3201,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.0.6.tgz",
       "integrity": "sha512-RDrsUR/BjwCECcWS+5bc7mWiU/M1IOizKt40Zuei5mn0Eydubiooh87aSCiZ/BGMSUF7P8AqyMEqQL0RsAihmw=="
     },
-    "eslint-restricted-globals": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-restricted-globals/-/eslint-restricted-globals-0.2.0.tgz",
-      "integrity": "sha512-kwYJALm5KS2QW3Mc1PgObO4V+pTR6RQtRT65L1GQILlEnAhabUQqGAX7/qUjoQR4KZJKehWpBtyDEiDecwmY9A=="
-    },
     "eslint-rule-documentation": {
       "version": "1.0.23",
       "resolved": "https://registry.npmjs.org/eslint-rule-documentation/-/eslint-rule-documentation-1.0.23.tgz",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "^7.20.3",
-    "eslint-plugin-react-hooks": "^4.0.6",
-    "eslint-restricted-globals": "^0.2.0"
+    "eslint-plugin-react-hooks": "^4.0.6"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "2.34.0",

--- a/rules/core/variables.js
+++ b/rules/core/variables.js
@@ -1,11 +1,18 @@
-const restrictedGlobals = require("eslint-restricted-globals");
-
 module.exports = {
   rules: {
     "init-declarations": "off",
     "no-delete-var": "error",
     "no-label-var": "error",
-    "no-restricted-globals": ["error", "isFinite", "isNaN", "alert"].concat(restrictedGlobals),
+    "no-restricted-globals": [
+      "error",
+      /* eslint-disable sort-keys */
+      { name: "isFinite", message: "Use `Number.isFinite` instead." },
+      { name: "isNaN", message: "Use `Number.isNaN` instead." },
+      { name: "alert", message: "Use `window.alert` instead." },
+      { name: "confirm", message: "Use `window.confirm` instead." },
+      { name: "location", message: "Use `window.location` instead." },
+      /* eslint-enable sort-keys */
+    ],
     "no-shadow": "error",
     "no-shadow-restricted-names": "error",
     "no-undef": "error",


### PR DESCRIPTION
BREAKING CHANGE: The `no-restricted-globals` rule warns fewer global variables.
Most global variables has not been used actually.