### PR TITLE
ci: replace GITHUB_TOKEN with PERSONAL_ACCESS_TOKEN

### DIFF
--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ybiquitous/npm-audit-fix-action@v1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
The `GITHUB_TOKEN` permissions cannot trigger other events (e.g. `push`).

https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token
