### PR TITLE
feat(import): use core rule instead of plugin rule

### DIFF
--- a/rules/core/es6.js
+++ b/rules/core/es6.js
@@ -12,7 +12,7 @@ module.exports = {
     "no-class-assign": "error",
     "no-const-assign": "error",
     "no-dupe-class-members": "error",
-    "no-duplicate-imports": "off", // => `import/no-duplicates`
+    "no-duplicate-imports": "error",
     "no-new-symbol": "error",
     "no-restricted-exports": "off",
     "no-restricted-imports": "off",

--- a/rules/plugins/import.js
+++ b/rules/plugins/import.js
@@ -24,6 +24,7 @@ module.exports = {
     "import/no-cycle": "error",
     "import/no-default-export": "off",
     "import/no-deprecated": "error",
+    "import/no-duplicates": "off", // use core rule `no-duplicate-imports`
     "import/no-dynamic-require": "warn",
     "import/no-extraneous-dependencies": [
       "error",


### PR DESCRIPTION
The `eslint-plugin-import` document says:

> If the core ESLint version is good enough (...), keep it and don't use this.

https://github.com/benmosher/eslint-plugin-import/blob/v2.22.1/docs/rules/no-duplicates.md#when-not-to-use-it

Note that `@typescript-eslint/no-duplicate-imports` also is present now.

https://github.com/ybiquitous/eslint-config-ybiquitous/blob/908bc4add9728db937829f8f1198f57eda6c5fd6/rules/plugins/typescript.js#L36