### PR TITLE
chore(deps): leave `versioning-strategy` the default value

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,6 @@ updates:
       time: "20:00"
       timezone: Asia/Tokyo
     open-pull-requests-limit: 10
-    versioning-strategy: increase
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
Maybe `versioning-strategy` should be set automatically:

https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#versioning-strategy