### PR TITLE
refactor(deps-dev): goodbye `execa`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "eslint": "7.12.1",
     "eslint-find-rules": "3.6.1",
     "eslint-plugin-jest": "24.1.0",
-    "execa": "4.0.3",
     "jest": "26.6.3",
     "prettier": "2.1.2",
     "semver": "7.3.2",


### PR DESCRIPTION
Replace `execa` with `child_process.processFileSync`:
https://nodejs.org/api/child_process.html#child_process_child_process_execfilesync_file_args_options
