### PR TITLE
feat(core): loosen `arrow-body-style` (error -> warn)

### DIFF
--- a/rules/core/es6.js
+++ b/rules/core/es6.js
@@ -6,7 +6,7 @@ module.exports = {
   },
 
   rules: {
-    "arrow-body-style": "error",
+    "arrow-body-style": "warn",
     "constructor-super": "error",
     "generator-star-spacing": "error",
     "no-class-assign": "error",


### PR DESCRIPTION
The [`arrow-body-style`](https://eslint.org/docs/rules/arrow-body-style) rule is related to the code style, so the `error` severity is too strict.