### PR TITLE
fix(import): better sorting imports

### DIFF
--- a/rules/core/es6.js
+++ b/rules/core/es6.js
@@ -30,7 +30,7 @@ module.exports = {
     "prefer-spread": "error",
     "prefer-template": "error",
     "require-yield": "error",
-    "sort-imports": "error",
+    "sort-imports": "off", // Use `import/order` instead.
     "symbol-description": "error",
   },
 };

--- a/rules/plugins/import.js
+++ b/rules/plugins/import.js
@@ -56,7 +56,7 @@ module.exports = {
     "import/no-unused-modules": "warn",
     "import/no-useless-path-segments": "error",
     "import/no-webpack-loader-syntax": "error",
-    "import/order": "error",
+    "import/order": ["error", { alphabetize: { order: "asc" } }],
     "import/prefer-default-export": "error",
     "import/unambiguous": "off",
   },

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -1,6 +1,6 @@
-const path = require("path");
 const fs = require("fs");
 const { EOL } = require("os");
+const path = require("path");
 const pkg = require("../package.json");
 const { sandbox, $ } = require("./helper");
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,7 +1,7 @@
-const path = require("path");
+const { execFileSync } = require("child_process");
 const fs = require("fs");
 const { EOL } = require("os");
-const { execFileSync } = require("child_process");
+const path = require("path");
 
 const BASE_DIR = path.join(__dirname, "..");
 const TMP_DIR = path.join(BASE_DIR, "tmp") + path.sep;


### PR DESCRIPTION
- Disable `sort-imports` (core)
  - https://eslint.org/docs/rules/sort-imports
- Enable `alphabetize` option of `import/order` (plugin)
  - https://github.com/benmosher/eslint-plugin-import/blob/v2.23.2/docs/rules/order.md