### PR TITLE
feat(import): disable `import/prefer-default-export`

### DIFF
--- a/rules/plugins/import.js
+++ b/rules/plugins/import.js
@@ -57,7 +57,7 @@ module.exports = {
     "import/no-useless-path-segments": "error",
     "import/no-webpack-loader-syntax": "error",
     "import/order": ["error", { alphabetize: { order: "asc" } }],
-    "import/prefer-default-export": "error",
+    "import/prefer-default-export": "off",
     "import/unambiguous": "off",
   },
 


### PR DESCRIPTION
This rule is for a code style, which can change depending on the context.

https://github.com/benmosher/eslint-plugin-import/blob/v2.23.2/docs/rules/prefer-default-export.md