### PR TITLE
fix(import): set `ignorePackages` to `import/extensions`

### DIFF
--- a/rules/plugins/import.js
+++ b/rules/plugins/import.js
@@ -6,7 +6,7 @@ module.exports = {
     "import/exports-last": "off",
     "import/extensions": [
       "error",
-      "always",
+      "ignorePackages",
       {
         js: "never",
         jsx: "never",


### PR DESCRIPTION
The `ignorePackages` option is useful for packages whose name includes an extension.
https://github.com/benmosher/eslint-plugin-import/blob/v2.23.2/docs/rules/extensions.md