### PR TITLE
feat(node): enable rules for ESM

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,13 @@ module.exports = {
 
   extends: ["./node.js"],
 
+  // TODO: Remove this configuration after the migration to ESM will complete.
+  globals: {
+    module: true,
+    require: true,
+    __dirname: true,
+  },
+
   overrides: [
     {
       files: ["rules/**/*.js"],

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "repository": "ybiquitous/eslint-config-ybiquitous",
   "engines": {
-    "node": ">=12.10.0"
+    "node": ">=12.20.0"
   },
   "dependencies": {
     "eslint-config-prettier": "^8.1.0",

--- a/rules/plugins/import.js
+++ b/rules/plugins/import.js
@@ -8,7 +8,6 @@ module.exports = {
       "error",
       "ignorePackages",
       {
-        js: "never",
         jsx: "never",
         ts: "never",
       },

--- a/rules/plugins/node.js
+++ b/rules/plugins/node.js
@@ -1,5 +1,14 @@
 module.exports = {
-  extends: ["plugin:node/recommended"],
+  env: {
+    es2020: true,
+  },
+
+  extends: ["plugin:node/recommended-module"],
+
+  parserOptions: {
+    ecmaVersion: 2020,
+  },
+
   rules: {
     "node/callback-return": "warn",
     "node/exports-style": ["error", "module.exports"],

--- a/test/check-rules.test.js
+++ b/test/check-rules.test.js
@@ -1,5 +1,5 @@
 const { EOL } = require("os");
-const { $ } = require("./helper");
+const { $ } = require("./helper.js");
 
 const checkRules = (file, option, env = {}) => {
   try {

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 const { EOL } = require("os");
 const path = require("path");
 const pkg = require("../package.json");
-const { sandbox, $ } = require("./helper");
+const { sandbox, $ } = require("./helper.js");
 
 const baseDir = path.join(__dirname, "..");
 

--- a/test/ecma-version.test.js
+++ b/test/ecma-version.test.js
@@ -1,9 +1,10 @@
-const { $ } = require("./helper");
+const { $ } = require("./helper.js");
 
 test("set correct `ecmaVersion`", () => {
   const runTest = (file) => {
     const stdout = JSON.parse($("eslint", "--print-config", file));
-    expect(stdout.parserOptions.ecmaVersion).toEqual(2019);
+    expect(stdout.parserOptions.ecmaVersion).toEqual(2020);
+    expect(stdout.env.es2020).toEqual(true);
     return true;
   };
 


### PR DESCRIPTION
BREAKING CHANGE: This package now targets ESM, not CommonJS. Also, it requires Node.js 12.20.0+.