### PR TITLE
fix(node): disable `node/no-extraneous-import`

### DIFF
--- a/rules/plugins/node.js
+++ b/rules/plugins/node.js
@@ -16,6 +16,7 @@ module.exports = {
     "node/global-require": "off",
     "node/handle-callback-err": "warn",
     "node/no-callback-literal": "off",
+    "node/no-extraneous-import": "off", // Use `import/no-extraneous-dependencies` instead.
     "node/no-mixed-requires": "off",
     "node/no-new-require": "warn",
     "node/no-path-concat": "error",


### PR DESCRIPTION
This rule is duplicated with `import/no-extraneous-dependencies`.

https://github.com/ybiquitous/eslint-config-ybiquitous/blob/5556914bcf5bcffe610c805376e7f67983bc2e7e/rules/plugins/import.js#L28-L29

See also:
- https://github.com/mysticatea/eslint-plugin-node/blob/cd97880ca2792db47c7952ac517e9e32d2ec783e/docs/rules/no-extraneous-import.md
- https://github.com/benmosher/eslint-plugin-import/blob/b39770d98c3ba9af8f9df8c8d6357b17ab9af786/docs/rules/no-extraneous-dependencies.md