### PR TITLE
fix(core): allow `__dirname` and `__filename` for `no-underscore-dangle`

### DIFF
--- a/rules/core/styles.js
+++ b/rules/core/styles.js
@@ -46,6 +46,7 @@ module.exports = {
     "no-underscore-dangle": [
       "error",
       {
+        allow: ["__dirname", "__filename"],
         allowAfterSuper: false,
         allowAfterThis: false,
         enforceInMethodNames: false,


### PR DESCRIPTION
Within an ESM module, the following idiom can be used:

```js
const __dirname = path.dirname(fileURLToPath(import.meta.url));
```

See also <https://nodejs.org/api/esm.html#no-__filename-or-__dirname>