### PR TITLE
feat!: drop Node.js v12 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ["12", "14", "16", "18"]
+        node-version: ["14", "16", "18"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "ybiq": "^14.3.0"
       },
       "engines": {
-        "node": ">=12.20.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "@typescript-eslint/eslint-plugin": ">=5.30.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "repository": "ybiquitous/eslint-config-ybiquitous",
   "engines": {
-    "node": ">=12.20.0"
+    "node": ">=14"
   },
   "dependencies": {
     "eslint-config-prettier": "^8.5.0",


### PR DESCRIPTION
v12 is End-of-Life. See https://nodejs.org/en/about/releases/
