### PR TITLE
feat!: drop Node.js 14 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["14", "16", "18", "20"]
+        node-version: ["16", "18", "20"]
     uses: ybiquitous/.github/.github/workflows/nodejs-test-reusable.yml@main
     with:
       node-version: ${{ matrix.node-version }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "ybiq": "^15.6.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "@typescript-eslint/eslint-plugin": ">=5.50.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "repository": "ybiquitous/eslint-config-ybiquitous",
   "engines": {
-    "node": ">=14"
+    "node": ">=16.0.0"
   },
   "dependencies": {
     "eslint-config-prettier": "^8.6.0",


### PR DESCRIPTION
Node.js 14 is EOL. See https://github.com/nodejs/release#release-schedule
