### PR TITLE
build(deps): npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -162,13 +162,13 @@
       }
     },
     "node_modules/@commitlint/cli": {
-      "version": "17.6.3",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.6.3.tgz",
-      "integrity": "sha512-ItSz2fd4F+CujgIbQOfNNerDF1eFlsBGEfp9QcCb1kxTYMuKTYZzA6Nu1YRRrIaaWwe2E7awUGpIMrPoZkOG3A==",
+      "version": "17.6.5",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.6.5.tgz",
+      "integrity": "sha512-3PQrWr/uo6lzF5k7n5QuosCYnzaxP9qGBp3jhWP0Vmsa7XA6wrl9ccPqfQyXpSbQE3zBROVO3TDqgPKe4tfmLQ==",
       "dev": true,
       "dependencies": {
         "@commitlint/format": "^17.4.4",
-        "@commitlint/lint": "^17.6.3",
+        "@commitlint/lint": "^17.6.5",
         "@commitlint/load": "^17.5.0",
         "@commitlint/read": "^17.5.1",
         "@commitlint/types": "^17.4.4",
@@ -368,9 +368,9 @@
       }
     },
     "node_modules/@commitlint/is-ignored": {
-      "version": "17.6.3",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-17.6.3.tgz",
-      "integrity": "sha512-LQbNdnPbxrpbcrVKR5yf51SvquqktpyZJwqXx3lUMF6+nT9PHB8xn3wLy8pi2EQv5Zwba484JnUwDE1ygVYNQA==",
+      "version": "17.6.5",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-17.6.5.tgz",
+      "integrity": "sha512-CQvAPt9gX7cuUbMrIaIMKczfWJqqr6m8IlJs0F2zYwyyMTQ87QMHIj5jJ5HhOaOkaj6dvTMVGx8Dd1I4xgUuoQ==",
       "dev": true,
       "dependencies": {
         "@commitlint/types": "^17.4.4",
@@ -408,14 +408,14 @@
       }
     },
     "node_modules/@commitlint/lint": {
-      "version": "17.6.3",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.6.3.tgz",
-      "integrity": "sha512-fBlXwt6SHJFgm3Tz+luuo3DkydAx9HNC5y4eBqcKuDuMVqHd2ugMNr+bQtx6riv9mXFiPoKp7nE4Xn/ls3iVDA==",
+      "version": "17.6.5",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.6.5.tgz",
+      "integrity": "sha512-BSJMwkE4LWXrOsiP9KoHG+/heSDfvOL/Nd16+ojTS/DX8HZr8dNl8l3TfVr/d/9maWD8fSegRGtBtsyGuugFrw==",
       "dev": true,
       "dependencies": {
-        "@commitlint/is-ignored": "^17.6.3",
-        "@commitlint/parse": "^17.4.4",
-        "@commitlint/rules": "^17.6.1",
+        "@commitlint/is-ignored": "^17.6.5",
+        "@commitlint/parse": "^17.6.5",
+        "@commitlint/rules": "^17.6.5",
         "@commitlint/types": "^17.4.4"
       },
       "engines": {
@@ -466,9 +466,9 @@
       }
     },
     "node_modules/@commitlint/parse": {
-      "version": "17.4.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-17.4.4.tgz",
-      "integrity": "sha512-EKzz4f49d3/OU0Fplog7nwz/lAfXMaDxtriidyGF9PtR+SRbgv4FhsfF310tKxs6EPj8Y+aWWuX3beN5s+yqGg==",
+      "version": "17.6.5",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-17.6.5.tgz",
+      "integrity": "sha512-0zle3bcn1Hevw5Jqpz/FzEWNo2KIzUbc1XyGg6WrWEoa6GH3A1pbqNF6MvE6rjuy6OY23c8stWnb4ETRZyN+Yw==",
       "dev": true,
       "dependencies": {
         "@commitlint/types": "^17.4.4",
@@ -522,9 +522,9 @@
       }
     },
     "node_modules/@commitlint/rules": {
-      "version": "17.6.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-17.6.1.tgz",
-      "integrity": "sha512-lUdHw6lYQ1RywExXDdLOKxhpp6857/4c95Dc/1BikrHgdysVUXz26yV0vp1GL7Gv+avx9WqZWTIVB7pNouxlfw==",
+      "version": "17.6.5",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-17.6.5.tgz",
+      "integrity": "sha512-uTB3zSmnPyW2qQQH+Dbq2rekjlWRtyrjDo4aLFe63uteandgkI+cc0NhhbBAzcXShzVk0qqp8SlkQMu0mgHg/A==",
       "dev": true,
       "dependencies": {
         "@commitlint/ensure": "^17.4.4",
@@ -9783,9 +9783,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"


### PR DESCRIPTION
This pull request fixes the vulnerable packages via npm [9.7.2](https://github.com/npm/cli/releases/tag/v9.7.2).

<details open>
<summary><strong>Updated (6)</strong></summary>

| Package | Version | Source | Detail |
|:--------|:-------:|:------:|:-------|
| [@commitlint/cli](https://www.npmjs.com/package/@commitlint/cli/v/17.6.5) | `17.6.3` → `17.6.5` | [github](https://github.com/conventional-changelog/commitlint) | - |
| [@commitlint/is-ignored](https://www.npmjs.com/package/@commitlint/is-ignored/v/17.6.5) | `17.6.3` → `17.6.5` | [github](https://github.com/conventional-changelog/commitlint) | - |
| [@commitlint/lint](https://www.npmjs.com/package/@commitlint/lint/v/17.6.5) | `17.6.3` → `17.6.5` | [github](https://github.com/conventional-changelog/commitlint) | - |
| [@commitlint/parse](https://www.npmjs.com/package/@commitlint/parse/v/17.6.5) | `17.4.4` → `17.6.5` | [github](https://github.com/conventional-changelog/commitlint) | - |
| [@commitlint/rules](https://www.npmjs.com/package/@commitlint/rules/v/17.6.5) | `17.6.1` → `17.6.5` | [github](https://github.com/conventional-changelog/commitlint) | - |
| [semver](https://www.npmjs.com/package/semver/v/7.5.3) | `7.5.1` → `7.5.3` | [github](https://github.com/npm/node-semver) | **[Moderate]** semver vulnerable to Regular Expression Denial of Service ([ref](https://github.com/advisories/GHSA-c2qf-rxjj-qqgw)) |

</details>

***

Created by [ybiquitous/npm-audit-fix-action](https://github.com/ybiquitous/npm-audit-fix-action)