### PR TITLE
build(deps): npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -162,13 +162,13 @@
       }
     },
     "node_modules/@commitlint/cli": {
-      "version": "17.6.5",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.6.5.tgz",
-      "integrity": "sha512-3PQrWr/uo6lzF5k7n5QuosCYnzaxP9qGBp3jhWP0Vmsa7XA6wrl9ccPqfQyXpSbQE3zBROVO3TDqgPKe4tfmLQ==",
+      "version": "17.6.6",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.6.6.tgz",
+      "integrity": "sha512-sTKpr2i/Fjs9OmhU+beBxjPavpnLSqZaO6CzwKVq2Tc4UYVTMFgpKOslDhUBVlfAUBfjVO8ParxC/MXkIOevEA==",
       "dev": true,
       "dependencies": {
         "@commitlint/format": "^17.4.4",
-        "@commitlint/lint": "^17.6.5",
+        "@commitlint/lint": "^17.6.6",
         "@commitlint/load": "^17.5.0",
         "@commitlint/read": "^17.5.1",
         "@commitlint/types": "^17.4.4",
@@ -368,13 +368,13 @@
       }
     },
     "node_modules/@commitlint/is-ignored": {
-      "version": "17.6.5",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-17.6.5.tgz",
-      "integrity": "sha512-CQvAPt9gX7cuUbMrIaIMKczfWJqqr6m8IlJs0F2zYwyyMTQ87QMHIj5jJ5HhOaOkaj6dvTMVGx8Dd1I4xgUuoQ==",
+      "version": "17.6.6",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-17.6.6.tgz",
+      "integrity": "sha512-4Fw875faAKO+2nILC04yW/2Vy/wlV3BOYCSQ4CEFzriPEprc1Td2LILmqmft6PDEK5Sr14dT9tEzeaZj0V56Gg==",
       "dev": true,
       "dependencies": {
         "@commitlint/types": "^17.4.4",
-        "semver": "7.5.0"
+        "semver": "7.5.2"
       },
       "engines": {
         "node": ">=v14"
@@ -393,9 +393,9 @@
       }
     },
     "node_modules/@commitlint/is-ignored/node_modules/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
+      "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -408,12 +408,12 @@
       }
     },
     "node_modules/@commitlint/lint": {
-      "version": "17.6.5",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.6.5.tgz",
-      "integrity": "sha512-BSJMwkE4LWXrOsiP9KoHG+/heSDfvOL/Nd16+ojTS/DX8HZr8dNl8l3TfVr/d/9maWD8fSegRGtBtsyGuugFrw==",
+      "version": "17.6.6",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.6.6.tgz",
+      "integrity": "sha512-5bN+dnHcRLkTvwCHYMS7Xpbr+9uNi0Kq5NR3v4+oPNx6pYXt8ACuw9luhM/yMgHYwW0ajIR20wkPAFkZLEMGmg==",
       "dev": true,
       "dependencies": {
-        "@commitlint/is-ignored": "^17.6.5",
+        "@commitlint/is-ignored": "^17.6.6",
         "@commitlint/parse": "^17.6.5",
         "@commitlint/rules": "^17.6.5",
         "@commitlint/types": "^17.4.4"
@@ -979,17 +979,17 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.41.0.tgz",
-      "integrity": "sha512-LxcyMGxwmTh2lY9FwHPGWOHmYFCZvbrFCBZL4FzSSsxsRPuhrYUg/49/0KDfW8tnIEaEHtfmn6+NPN+1DqaNmA==",
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.43.0.tgz",
+      "integrity": "sha512-s2UHCoiXfxMvmfzqoN+vrQ84ahUSYde9qNO1MdxmoEhyHWsfmwOpFlwYV+ePJEVc7gFnATGUi376WowX1N7tFg==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
-      "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
+      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
@@ -3795,15 +3795,15 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.41.0.tgz",
-      "integrity": "sha512-WQDQpzGBOP5IrXPo4Hc0814r4/v2rrIsB0rhT7jtunIalgg6gYXWhRMOejVO8yH21T/FGaxjmFjBMNqcIlmH1Q==",
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.43.0.tgz",
+      "integrity": "sha512-aaCpf2JqqKesMFGgmRPessmVKjcGXqdlAYLLC3THM8t5nBRZRQ+st5WM/hoJXkdioEXLLbXgclUpM0TXo5HX5Q==",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
         "@eslint/eslintrc": "^2.0.3",
-        "@eslint/js": "8.41.0",
-        "@humanwhocodes/config-array": "^0.11.8",
+        "@eslint/js": "8.43.0",
+        "@humanwhocodes/config-array": "^0.11.10",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.10.0",


### PR DESCRIPTION
This pull request fixes the vulnerable packages via npm [9.7.2](https://github.com/npm/cli/releases/tag/v9.7.2).

<details open>
<summary><strong>Updated (7)</strong></summary>

| Package | Version | Source | Detail |
|:--------|:-------:|:------:|:-------|
| [@commitlint/cli](https://www.npmjs.com/package/@commitlint/cli/v/17.6.6) | `17.6.5` → `17.6.6` | [github](https://github.com/conventional-changelog/commitlint) | - |
| [@commitlint/is-ignored](https://www.npmjs.com/package/@commitlint/is-ignored/v/17.6.6) | `17.6.5` → `17.6.6` | [github](https://github.com/conventional-changelog/commitlint) | - |
| [@commitlint/lint](https://www.npmjs.com/package/@commitlint/lint/v/17.6.6) | `17.6.5` → `17.6.6` | [github](https://github.com/conventional-changelog/commitlint) | - |
| [@eslint/js](https://www.npmjs.com/package/@eslint/js/v/8.43.0) | `8.41.0` → `8.43.0` | [github](https://github.com/eslint/eslint) | - |
| [@humanwhocodes/config-array](https://www.npmjs.com/package/@humanwhocodes/config-array/v/0.11.10) | `0.11.8` → `0.11.10` | [github](https://github.com/humanwhocodes/config-array) | - |
| [eslint](https://www.npmjs.com/package/eslint/v/8.43.0) | `8.41.0` → `8.43.0` | [github](https://github.com/eslint/eslint) | - |
| [semver](https://www.npmjs.com/package/semver/v/7.5.2) (`@commitlint/is-ignored/node_modules/semver`) | `7.5.0` → `7.5.2` | [github](https://github.com/npm/node-semver) | **[Moderate]** semver vulnerable to Regular Expression Denial of Service ([ref](https://github.com/advisories/GHSA-c2qf-rxjj-qqgw)) |

</details>

***

Created by [ybiquitous/npm-audit-fix-action](https://github.com/ybiquitous/npm-audit-fix-action)