### PR TITLE
build(deps): npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1161,9 +1161,9 @@
       }
     },
     "node_modules/@mdn/browser-compat-data": {
-      "version": "5.2.59",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.59.tgz",
-      "integrity": "sha512-f7VxPGqVLCSe+0KdDas33JyGY+eHJTfBkgAsoiM1BSv7e238FYJMTFwfGLhjnhOwc33wUwsnjiHSfXukwzbqog=="
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.3.14.tgz",
+      "integrity": "sha512-Y9XQrphVcE6u9xMm+gIqN86opbU/5s2W1pdPyKRyFV5B7+2jWM2gLI5JpfhZncaoDKvhy6FYwK04aCz5UM/bTQ=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1510,7 +1510,8 @@
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "16.1.0",
@@ -2291,9 +2292,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.5",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
-      "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
+      "version": "4.21.10",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
+      "integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -2302,13 +2303,17 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001449",
-        "electron-to-chromium": "^1.4.284",
-        "node-releases": "^2.0.8",
-        "update-browserslist-db": "^1.0.10"
+        "caniuse-lite": "^1.0.30001517",
+        "electron-to-chromium": "^1.4.477",
+        "node-releases": "^2.0.13",
+        "update-browserslist-db": "^1.0.11"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2379,9 +2384,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001488",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001488.tgz",
-      "integrity": "sha512-NORIQuuL4xGpIy6iCCQGN4iFjlBXtfKWIenlUuyZJumLRIindLb7wXM+GO8erEhb7vXfcnf4BAg2PrSDN5TNLQ==",
+      "version": "1.0.30001524",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001524.tgz",
+      "integrity": "sha512-Jj917pJtYg9HSJBF95HVX3Cdr89JUyLT4IZ8SvM5aDRni95swKgYi3TgYLH5hnGfPE/U1dg6IfZ50UsIlLkwSA==",
       "funding": [
         {
           "type": "opencollective",
@@ -3434,9 +3439,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.402",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.402.tgz",
-      "integrity": "sha512-gWYvJSkohOiBE6ecVYXkrDgNaUjo47QEKK0kQzmWyhkH+yoYiG44bwuicTGNSIQRG3WDMsWVZJLRnJnLNkbWvA=="
+      "version": "1.4.505",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.505.tgz",
+      "integrity": "sha512-0A50eL5BCCKdxig2SsCXhpuztnB9PfUgRMojj5tMvt8O54lbwz3t6wNgnpiTRosw5QjlJB7ixhVyeg8daLQwSQ=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -3754,49 +3759,23 @@
       }
     },
     "node_modules/eslint-plugin-compat": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-4.1.4.tgz",
-      "integrity": "sha512-RxySWBmzfIROLFKgeJBJue2BU/6vM2KJWXWAUq+oW4QtrsZXRxbjgxmO1OfF3sHcRuuIenTS/wgo3GyUWZF24w==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-4.2.0.tgz",
+      "integrity": "sha512-RDKSYD0maWy5r7zb5cWQS+uSPc26mgOzdORJ8hxILmWM7S/Ncwky7BcAtXVY5iRbKjBdHsWU8Yg7hfoZjtkv7w==",
       "dependencies": {
-        "@mdn/browser-compat-data": "^5.2.47",
-        "@tsconfig/node14": "^1.0.3",
+        "@mdn/browser-compat-data": "^5.3.13",
         "ast-metadata-inferer": "^0.8.0",
-        "browserslist": "^4.21.5",
-        "caniuse-lite": "^1.0.30001473",
+        "browserslist": "^4.21.10",
+        "caniuse-lite": "^1.0.30001524",
         "find-up": "^5.0.0",
-        "lodash.memoize": "4.1.2",
-        "semver": "7.3.8"
+        "lodash.memoize": "^4.1.2",
+        "semver": "^7.5.4"
       },
       "engines": {
         "node": ">=14.x"
       },
       "peerDependencies": {
         "eslint": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-compat/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/eslint-plugin-compat/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/eslint-plugin-es": {
@@ -7232,9 +7211,9 @@
       "dev": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
-      "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w=="
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ=="
     },
     "node_modules/nopt": {
       "version": "7.1.0",
@@ -9552,7 +9531,6 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -9567,7 +9545,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },


### PR DESCRIPTION
This pull request fixes the vulnerable packages via npm [9.8.1](https://github.com/npm/cli/releases/tag/v9.8.1).

<details open>
<summary><strong>Updated (6)</strong></summary>

| Package | Version | Source | Detail |
|:--------|:-------:|:------:|:-------|
| [@mdn/browser-compat-data](https://www.npmjs.com/package/@mdn/browser-compat-data/v/5.3.14) | `5.2.59` → `5.3.14` | [github](https://github.com/mdn/browser-compat-data) | - |
| [browserslist](https://www.npmjs.com/package/browserslist/v/4.21.10) | `4.21.5` → `4.21.10` | [github](https://github.com/browserslist/browserslist) | - |
| [caniuse-lite](https://www.npmjs.com/package/caniuse-lite/v/1.0.30001524) | `1.0.30001488` → `1.0.30001524` | [github](https://github.com/browserslist/caniuse-lite) | - |
| [electron-to-chromium](https://www.npmjs.com/package/electron-to-chromium/v/1.4.505) | `1.4.402` → `1.4.505` | [github](https://github.com/kilian/electron-to-chromium) | - |
| [eslint-plugin-compat](https://www.npmjs.com/package/eslint-plugin-compat/v/4.2.0) | `4.1.4` → `4.2.0` | [github](https://github.com/amilajack/eslint-plugin-compat) | - |
| [node-releases](https://www.npmjs.com/package/node-releases/v/2.0.13) | `2.0.10` → `2.0.13` | [github](https://github.com/chicoxyzzy/node-releases) | - |

</details>

<details open>
<summary><strong>Removed (2)</strong></summary>

| Package | Version | Source | Detail |
|:--------|:-------:|:------:|:-------|
| [lru-cache](https://www.npmjs.com/package/lru-cache/v/6.0.0) (`eslint-plugin-compat/node_modules/lru-cache`) | `6.0.0` | [github](https://github.com/isaacs/node-lru-cache) | - |
| [semver](https://www.npmjs.com/package/semver/v/7.3.8) (`eslint-plugin-compat/node_modules/semver`) | `7.3.8` | [github](https://github.com/npm/node-semver) | **[Moderate]** semver vulnerable to Regular Expression Denial of Service ([ref](https://github.com/advisories/GHSA-c2qf-rxjj-qqgw)) |

</details>

***

Created by [ybiquitous/npm-audit-fix-action](https://github.com/ybiquitous/npm-audit-fix-action)