### PR TITLE
ci: fix failed "npm audit fix" workflow

### DIFF
--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -13,6 +13,9 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
       - uses: ybiquitous/npm-audit-fix-action@v6
         with:
           github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
The default Node.js version mismatches with the required version. See the error:

```
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: @eslint/eslintrc@3.0.2
npm ERR! notsup Not compatible with your version of node/npm: @eslint/eslintrc@3.0.2
npm ERR! notsup Required: {"node":"^18.18.0 || ^20.9.0 || >=21.1.0"}
npm ERR! notsup Actual:   {"npm":"10.5.0","node":"v20.8.1"}
```

https://github.com/ybiquitous/eslint-config-ybiquitous/actions/runs/8118710326/job/22193458998#step:3:55