### PR TITLE
fix(deps): stop supporting @typescript-eslint/eslint-plugin v8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": ">=7.4.0",
+        "@typescript-eslint/eslint-plugin": ">=7.4.0 <8.0.0",
         "eslint": ">=8.50.0"
       },
       "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "ybiq": "^17.3.0"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": ">=7.4.0",
+    "@typescript-eslint/eslint-plugin": ">=7.4.0 <8.0.0",
     "eslint": ">=8.50.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
Because the E2E test fails.