### PR TITLE
chore(github): support npm trusted publishing with OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,6 @@ on:
 jobs:
   release:
     uses: ybiquitous/.github/.github/workflows/nodejs-release-reusable.yml@main
-    secrets:
-      npm-token: ${{ secrets.NPM_TOKEN }}
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
Secrets will be no longer necessary.

Ref https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/